### PR TITLE
chore: remove QUERY_ALL_PACKAGES

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
 
     <queries>
         <intent>

--- a/lib/ui/helper/launch_helper.dart
+++ b/lib/ui/helper/launch_helper.dart
@@ -18,10 +18,6 @@ Future<void> openYoutubePlaylist(String playlistId) async {
       }
     }
   } else {
-    if (await canLaunchUrl(youtubeWebUri)) {
-      await launchUrl(youtubeWebUri);
-    } else {
-      throw Exception('Could not launch https://$url');
-    }
+    await launchUrl(youtubeWebUri);
   }
 }


### PR DESCRIPTION

# :wrench: Bugfixes



---

#### :pencil2: Description:

Remove QUERY_ALL_PACKAGES from android manifest because it wasn’t necessary 

---



